### PR TITLE
feat: allow to retrieve transactions by account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ default: help
 test: ## run fast go tests
 	@go test ./... -cover
 
-it-tst: ## run the tests with all databases
-	@go test ./... -cover --alldbs
+it-test: ## run db IT tests
+	@cd internal/accounting && go test -v --alldbs
+	@cd internal/backup && go test -v --alldbs
+
 
 lint: ## run go linter
 	# depends on https://github.com/golangci/golangci-lint

--- a/app/router/handlers/finance/account_test.go
+++ b/app/router/handlers/finance/account_test.go
@@ -767,6 +767,13 @@ func sampleData(t *testing.T, store *accounting.Store) {
 		}
 	}
 
+	// create an entry with time now for test purposes
+	entry := accounting.Expense{Description: "now1", Amount: 1, AccountID: 1, Date: time.Now()}
+	_, err = store.CreateTransaction(context.Background(), entry, tenant1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, entry := range sampleEntries2 {
 		_, err = store.CreateTransaction(context.Background(), entry, tenant2)
 		if err != nil {

--- a/app/router/handlers/finance/report.go
+++ b/app/router/handlers/finance/report.go
@@ -35,12 +35,12 @@ func (h *Handler) IncomeExpenseReport(userId string) http.Handler {
 		}
 
 		now := time.Now()
-		endDate, err := parseDate(r.URL.Query().Get("endDate"), now)
+		endDate, err := parseDateOrDefault(r.URL.Query().Get("endDate"), now)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to parse end date: %s", err), http.StatusBadRequest)
 			return
 		}
-		startDate, err := parseDate(r.URL.Query().Get("startDate"), endDate.AddDate(0, 0, -30))
+		startDate, err := parseDateOrDefault(r.URL.Query().Get("startDate"), endDate.AddDate(0, 0, -30))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to parse start date: %s", err), http.StatusBadRequest)
 			return
@@ -109,24 +109,20 @@ func (h *Handler) IncomeExpenseReport(userId string) http.Handler {
 
 func getDateRange(startDateStr, endDateStr string, defaultStart, defaultEnd time.Time) (time.Time, time.Time, error) {
 
-	startDate, err := parseDate(startDateStr, defaultStart)
+	startDate, err := parseDateOrDefault(startDateStr, defaultStart)
 	if err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("unable to parse start date: %w", err)
 	}
 
-	endDate, err := parseDate(endDateStr, defaultEnd)
+	endDate, err := parseDateOrDefault(endDateStr, defaultEnd)
 	if err != nil {
 		return time.Time{}, time.Time{}, fmt.Errorf("unable to parse end date: %w", err)
 	}
 
-	// set the endDate time to midnight of the next day
-	endDate = endDate.AddDate(0, 0, 1)
-	endDate = time.Date(endDate.Year(), endDate.Month(), endDate.Day(), 0, 0, 0, 0, endDate.Location())
-
 	return startDate, endDate, nil
 }
 
-func parseDate(dateStr string, defaultDate time.Time) (time.Time, error) {
+func parseDateOrDefault(dateStr string, defaultDate time.Time) (time.Time, error) {
 	date := defaultDate
 	if dateStr != "" {
 		var err error
@@ -155,13 +151,13 @@ func (h *Handler) AccountBalance(userId string) http.Handler {
 			return
 		}
 
-		startDate, err := parseDate(r.URL.Query().Get("startDate"), time.Time{})
+		startDate, err := parseDateOrDefault(r.URL.Query().Get("startDate"), time.Time{})
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to parse start date: %s", err), http.StatusBadRequest)
 			return
 		}
 		now := time.Now()
-		endDate, err := parseDate(r.URL.Query().Get("endDate"), now)
+		endDate, err := parseDateOrDefault(r.URL.Query().Get("endDate"), now)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to parse end date: %s", err), http.StatusBadRequest)
 			return

--- a/app/router/handlers/finance/report_test.go
+++ b/app/router/handlers/finance/report_test.go
@@ -146,7 +146,7 @@ func TestFinanceHandler_AccountBalance(t *testing.T) {
 			query:      "?accountIds=1",
 			expectCode: http.StatusOK,
 			wantValue: map[uint][]float64{
-				1: {79},
+				1: {80},
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestFinanceHandler_AccountBalance(t *testing.T) {
 			query:      "?accountIds=1,2",
 			expectCode: http.StatusOK,
 			wantValue: map[uint][]float64{
-				1: {79},
+				1: {80},
 				2: {26},
 			},
 		},
@@ -165,7 +165,7 @@ func TestFinanceHandler_AccountBalance(t *testing.T) {
 			query:      "?accountIds=1,2&steps=3",
 			expectCode: http.StatusOK,
 			wantValue: map[uint][]float64{
-				1: {79, 79, 79},
+				1: {79, 79, 80},
 				2: {26, 26, 26},
 			},
 		},

--- a/app/router/handlers/finance/transaction.go
+++ b/app/router/handlers/finance/transaction.go
@@ -252,12 +252,32 @@ func (h *Handler) ListTx(userId string) http.Handler {
 			}
 		}
 
+		// parse account ids
+
+		var accountIds []int
+		accountIdsQuery := r.URL.Query().Get("accountIds")
+		if accountIdsQuery != "" {
+			ids := strings.Split(accountIdsQuery, ",")
+			if len(ids) > 0 {
+				for _, id := range ids {
+					var idInt int
+					if _, err := fmt.Sscanf(id, "%d", &idInt); err != nil {
+						http.Error(w, "invalid account ID format", http.StatusBadRequest)
+						return
+					}
+					accountIds = append(accountIds, idInt)
+				}
+			}
+		}
+
 		opts := accounting.ListOpts{
 			StartDate: startDate,
 			EndDate:   endDate,
 			Limit:     limit,
+			AccountId: accountIds,
 			Page:      page,
 		}
+
 		entries, err := h.Store.ListTransactions(r.Context(), opts, userId)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to list entries: %s", err.Error()), http.StatusInternalServerError)

--- a/internal/accounting/transaction.go
+++ b/internal/accounting/transaction.go
@@ -733,6 +733,9 @@ func (store *Store) ListTransactions(ctx context.Context, opts ListOpts, tenant 
 
 	db := store.db.WithContext(ctx).Table("db_transactions")
 
+	startDate := toDate(opts.StartDate)
+	endDate := endOfDay(opts.EndDate)
+
 	db = db.Select(`
         db_transactions.id AS transaction_id,
         db_transactions.date,
@@ -761,7 +764,7 @@ func (store *Store) ListTransactions(ctx context.Context, opts ListOpts, tenant 
 	// ensure proper owner
 	db = db.Where("db_entries.owner_id = ? AND db_transactions.owner_id = ? ", tenant, tenant)
 	// Filter by date range
-	db = db.Where("db_transactions.date BETWEEN ? AND ?", opts.StartDate, opts.EndDate)
+	db = db.Where("db_transactions.date BETWEEN ? AND ?", startDate, endDate)
 	// filter by type
 	if len(opts.Types) > 0 {
 		db = db.Where("db_transactions.type IN (?)", opts.Types)

--- a/internal/accounting/transaction_test.go
+++ b/internal/accounting/transaction_test.go
@@ -976,7 +976,7 @@ func TestStore_ListTransactions(t *testing.T) {
 				Types:     []TxType{IncomeTransaction},
 			},
 			want: []Transaction{
-				listTransactionsSampleData[12], listTransactionsSampleData[9],
+				listTransactionsSampleData[4], listTransactionsSampleData[12], listTransactionsSampleData[9],
 			},
 		},
 		{
@@ -988,7 +988,7 @@ func TestStore_ListTransactions(t *testing.T) {
 				Types:     []TxType{IncomeTransaction, ExpenseTransaction},
 			},
 			want: []Transaction{
-				listTransactionsSampleData[13], listTransactionsSampleData[12],
+				listTransactionsSampleData[4], listTransactionsSampleData[13], listTransactionsSampleData[12],
 				listTransactionsSampleData[10], listTransactionsSampleData[9],
 			},
 		},


### PR DESCRIPTION
this PR adds a new query parameter to the API that allows to retrieve transactions filtered by account IDs